### PR TITLE
accept public key of the other party in containers

### DIFF
--- a/lib/hm_crypto/container.ex
+++ b/lib/hm_crypto/container.ex
@@ -66,7 +66,7 @@ defmodule HmCrypto.Container do
           command,
           serial_number,
           Crypto.private_key(),
-          HmCrypto.AccessCertificate.access_certificate_binary(),
+          HmCrypto.AccessCertificate.access_certificate_binary() | HmCrypto.Crypto.public_key(),
           nonce
         ) :: secure_command
   def enclose(command, serial_number, private_key, access_certificate, nonce) do
@@ -88,7 +88,7 @@ defmodule HmCrypto.Container do
   @spec disclose(
           secure_command,
           Crypto.private_key(),
-          HmCrypto.AccessCertificate.access_certificate_binary()
+          HmCrypto.AccessCertificate.access_certificate_binary() | HmCrypto.Crypto.public_key()
         ) :: {:ok, command} | {:error, disclose_error}
   def disclose(container_data, private_key, access_certificate) do
     %{command: command, encrypted_flag: encrypted_flag?, target_serial: _, nonce: nonce} =
@@ -201,7 +201,7 @@ defmodule HmCrypto.Container do
   @spec enclose_command(
           binary,
           Crypto.private_key(),
-          HmCrypto.AccessCertificate.access_certificate_binary(),
+          HmCrypto.AccessCertificate.access_certificate_binary() | HmCrypto.Crypto.public_key(),
           nonce()
         ) :: binary
   def enclose_command(command, private_key, access_certificate, nonce) do
@@ -227,7 +227,7 @@ defmodule HmCrypto.Container do
   @spec disclose_command(
           binary,
           Crypto.private_key(),
-          HmCrypto.AccessCertificate.access_certificate_binary(),
+          HmCrypto.AccessCertificate.access_certificate_binary() | HmCrypto.Crypto.public_key(),
           nonce()
         ) :: {:ok, binary} | {:error, disclose_error}
   def disclose_command(encrypted_command, private_key, access_certificate, nonce) do


### PR DESCRIPTION
It's useful when we validate the pairs connection using record in database(not access certificate) and we just want to build the binary data using other parties public key as opposed to accepting access certificate and extract public key from that 