### PR TITLE
return ok/error tuple for disclose_command

### DIFF
--- a/lib/hm_crypto/container.ex
+++ b/lib/hm_crypto/container.ex
@@ -145,8 +145,7 @@ defmodule HmCrypto.Container do
         ) :: {:ok, command} | {:error, disclose_error} | {:error, container_parser_error}
   def disclose(container_data, private_key, access_certificate) do
     with {:ok, container} <- destruct_container(container_data),
-         {:ok, :encrypted} <-
-           encrypted?(container.encrypted_flag) do
+         {:ok, :encrypted} <- encrypted?(container.encrypted_flag) do
       disclose_command(container.command, private_key, access_certificate, container.nonce)
     else
       {:ok, :not_encrypted} ->

--- a/test/hm_crypto/container_test.exs
+++ b/test/hm_crypto/container_test.exs
@@ -59,6 +59,16 @@ defmodule HmCrypto.ContainerTest do
 
       assert Container.disclose_error(container_error) == {:ok, <<0x2, 0x36, 0x08>>}
     end
+
+    test "returns error when Error container is encrypted" do
+      encrypted_flag = 1
+
+      container_error =
+        <<0, 93, 151, 197, 254, 254, 242, 65, 186, 175, 170, 254, 0, 1, 2, 3, 4, 5, 6, 7, 8, 254,
+          encrypted_flag, 2, 54, 8, 255>>
+
+      assert Container.disclose_error(container_error) == {:error, :error_message_is_encrypted}
+    end
   end
 
   describe "destruct_container/1" do


### PR DESCRIPTION
It helps us to catch corner cases in production and handle it safely rather than throwing error